### PR TITLE
Add functionality to create gist from the editor

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,14 @@
     "rules": {
         "@typescript-eslint/naming-convention": "warn",
         "@typescript-eslint/semi": "warn",
+        "@typescript-eslint/quotes": [
+            "warn",
+            "double",
+            {
+              "avoidEscape": true,
+              "allowTemplateLiterals": true
+            }
+          ],
         "curly": "warn",
         "eqeqeq": "warn",
         "no-throw-literal": "warn",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "code-to-gist",
-  "version": "0.0.3",
+  "name": "Code-to-gist",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "code-to-gist",
-      "version": "0.0.3",
+      "name": "Code-to-gist",
+      "version": "0.2.1",
       "dependencies": {
         "@types/vscode": "^1.69.1",
         "axios": "^1.4.0"
@@ -15,12 +15,14 @@
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.1",
         "@types/node": "20.2.5",
+        "@types/vscode": "^1.69.1",
         "@typescript-eslint/eslint-plugin": "^5.59.8",
         "@typescript-eslint/parser": "^5.59.8",
         "@vscode/test-electron": "^2.3.2",
         "eslint": "^8.41.0",
         "glob": "^8.1.0",
         "mocha": "^10.2.0",
+        "prettier": "^2.8.8",
         "typescript": "^5.1.3"
       },
       "engines": {
@@ -203,7 +205,8 @@
     "node_modules/@types/vscode": {
       "version": "1.69.1",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.69.1.tgz",
-      "integrity": "sha512-YZ77g3u9S9Xw3dwAgRgNAwnKNS3nPlhSu3XKOIYQzCcItUrZovfJUlf/29wjON2VZvHGuYQnhKuJUP15ccpVIQ=="
+      "integrity": "sha512-YZ77g3u9S9Xw3dwAgRgNAwnKNS3nPlhSu3XKOIYQzCcItUrZovfJUlf/29wjON2VZvHGuYQnhKuJUP15ccpVIQ==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.59.9",
@@ -1925,6 +1928,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -2563,7 +2581,8 @@
     "@types/vscode": {
       "version": "1.69.1",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.69.1.tgz",
-      "integrity": "sha512-YZ77g3u9S9Xw3dwAgRgNAwnKNS3nPlhSu3XKOIYQzCcItUrZovfJUlf/29wjON2VZvHGuYQnhKuJUP15ccpVIQ=="
+      "integrity": "sha512-YZ77g3u9S9Xw3dwAgRgNAwnKNS3nPlhSu3XKOIYQzCcItUrZovfJUlf/29wjON2VZvHGuYQnhKuJUP15ccpVIQ==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.59.9",
@@ -2686,7 +2705,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "agent-base": {
       "version": "6.0.2",
@@ -3806,6 +3826,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -29,17 +29,51 @@
   ],
   "activationEvents": [
     "onAuthentication:github",
-    "onCommand:code-to-gist.createGist",
     "onStartupFinished"
   ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
       {
-        "command": "code-to-gist.createGist",
-        "title": "Code-To-Gist: Create GitHub Gist from VSCode"
+        "command": "code-to-gist.createGistFromActiveEditor",
+        "title": "Code-To-Gist: Create GitHub Gist from Active Editor",
+        "icon": "$(file-code)"
+      },
+      {
+        "command": "code-to-gist.createGistFromExplorer",
+        "title": "Create GitHub Gist from File"
+      },
+      {
+        "command": "code-to-gist.createGistFromFilePicker",
+        "title": "Create GitHub Gist from File Picker"
+      },
+      {
+        "command": "code-to-gist.createGistFromSelection",
+        "title": "Create GitHub Gist from Selection"
       }
-    ]
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "code-to-gist.createGistFromSelection",
+          "group": "9_cutcopypaste@5",
+          "when": "editorHasSelection"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "code-to-gist.createGistFromActiveEditor",
+          "group": "navigation",
+          "when": "textInputFocus"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "code-to-gist.createGistFromExplorer",
+          "group": "5_cutcopypaste"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
@@ -49,17 +83,32 @@
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js"
   },
+  "prettier": {
+    "singleQuote": false,
+    "overrides": [
+      {
+        "files": [
+          ".prettierrc",
+          ".eslintrc"
+        ],
+        "options": {
+          "parser": "json"
+        }
+      }
+    ]
+  },
   "devDependencies": {
-    "@types/vscode": "^1.69.1",
     "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.1",
     "@types/node": "20.2.5",
+    "@types/vscode": "^1.69.1",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "@typescript-eslint/parser": "^5.59.8",
     "@vscode/test-electron": "^2.3.2",
     "eslint": "^8.41.0",
     "glob": "^8.1.0",
     "mocha": "^10.2.0",
+    "prettier": "^2.8.8",
     "typescript": "^5.1.3"
   },
   "dependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,127 +1,275 @@
 import * as vscode from "vscode";
 import axios from "axios";
 import * as fs from "fs";
+import * as path from "path";
 
-export async function activate(context: vscode.ExtensionContext) {
-  let disposable = vscode.commands.registerCommand(
-    "code-to-gist.createGist",
-    async () => {
-      const session = await vscode.authentication.getSession(
-        "github",
-        ["gist"],
-        { createIfNone: true }
-      );
-      if (!session) {
-        vscode.window.showErrorMessage("GitHub authentication failed");
-        return;
-      }
-      const token = session.accessToken;
+interface Gist {
+  [key: string]: { content: string };
+}
 
-      const filesToUpload = await vscode.window.showOpenDialog({
-        canSelectMany: true,
-        canSelectFolders: false,
-      });
+const getSessionToken = async () => {
+  const session = await vscode.authentication.getSession("github", ["gist"], {
+    createIfNone: true,
+  });
+  if (!session) {
+    throw new Error("GitHub authentication failed");
+  }
 
-      if (!filesToUpload) {
-        vscode.window.showErrorMessage("Please select a file");
-        return;
-      }
+  return session.accessToken;
+};
 
-      const gistVisibility = await vscode.window.showQuickPick(
-        ["public", "secret"],
-        {
-          placeHolder: "Choose the gist visibility",
-        }
-      );
-
-      if (!gistVisibility) {
-        vscode.window.showErrorMessage("Please select a gist visibility");
-        return;
-      }
-
-      const gists: any[] = [];
-      for (const fileUri of filesToUpload) {
-        const fileName = fileUri.path.split("/").pop() || "";
-
-        let fileContent;
-        try {
-          fileContent = fs.readFileSync(fileUri.fsPath, "utf8");
-        } catch (e) {
-          vscode.window.showErrorMessage(
-            `Failed to read the file: ${fileName}`
-          );
-          throw e;
-        }
-
-        gists.push({
-          [fileName]: {
-            content: fileContent,
-          },
-        });
-      }
-
-      try {
-        const response = await axios.post(
-          "https://api.github.com/gists",
-          {
-            files: Object.assign({}, ...gists),
-            public: gistVisibility === "public",
-          },
-          {
-            headers: {
-              Authorization: `token ${token}`,
-            },
-          }
-        );
-
-        if (response.status === 201) {
-          const gistUrl = response.data.html_url;
-          const openGistButton = "Go to Gist";
-
-          const selectedButton = await vscode.window.showInformationMessage(
-            `Gist Created: ${gistUrl}`,
-            openGistButton
-          );
-
-          if (selectedButton === openGistButton) {
-            vscode.env.openExternal(vscode.Uri.parse(gistUrl));
-          }
-        } else {
-          throw new Error(
-            `GitHub API responded with status code ${response.status}`
-          );
-        }
-      } catch (e) {
-        if (axios.isAxiosError(e)) {
-          if (e.response?.status === 403) {
-            vscode.window.showErrorMessage(
-              "Rate limit exceeded. Please try again later."
-            );
-          } else if (e.response?.status === 401) {
-            vscode.window.showErrorMessage(
-              "Invalid GitHub PAT. Please check your token."
-            );
-          } else {
-            vscode.window.showErrorMessage(
-              `Failed to create a gist: ${e.message}`
-            );
-          }
-        } else {
-          vscode.window.showErrorMessage(
-            "An unexpected error occurred while creating a gist"
-          );
-        }
-      }
+const getGistVisibility = async () => {
+  const gistVisibility = await vscode.window.showQuickPick(
+    ["public", "secret"],
+    {
+      placeHolder: "Choose the gist visibility",
     }
   );
+  if (!gistVisibility) {
+    throw new Error("Please select a gist visibility");
+  }
 
-  context.subscriptions.push(disposable);
+  return gistVisibility === "public";
+};
+
+const readFilesRecursively = (filePath: string | undefined) => {
+  const gists: Gist[] = [];
+  if (!filePath) {
+    return gists;
+  }
+  const isMultiple = fs.statSync(filePath).isDirectory();
+
+  const _readFilesRecursively = (_filePath: string) => {
+    if (_filePath.split("/").pop() === "node_modules") {
+      vscode.window.showInformationMessage(
+        "Can't create a gist from node_modules"
+      );
+      return;
+    }
+    const isFile = !fs.statSync(_filePath).isDirectory();
+
+    const readSingleFile = (__filePath: string) => {
+      const fileName = __filePath.split("/").pop() || "";
+      const fileContent = fs.readFileSync(__filePath, "utf8");
+
+      if (!isMultiple) {
+        vscode.window.showInformationMessage(`Read file ${fileName}`);
+      }
+
+      gists.push({
+        [fileName]: {
+          content: fileContent,
+        },
+      });
+    };
+
+    if (isFile) {
+      readSingleFile(_filePath);
+      return;
+    }
+
+    const files = fs.readdirSync(_filePath);
+
+    files.forEach((file) => {
+      const itemPath = path.join(_filePath, file);
+
+      const isDirectory = fs.statSync(itemPath).isDirectory();
+
+      if (isDirectory) {
+        _readFilesRecursively(itemPath);
+        vscode.window.showInformationMessage(`Read multiple files...`);
+      } else {
+        readSingleFile(itemPath);
+      }
+    });
+  };
+
+  _readFilesRecursively(filePath);
+
+  return gists;
+};
+
+const uploadGistAndHandleErrors = async (
+  gists: Gist[],
+  isPublic: boolean,
+  token: string
+) => {
+  try {
+    const response = await axios.post(
+      "https://api.github.com/gists",
+      {
+        files: Object.assign({}, ...gists),
+        public: isPublic,
+      },
+      {
+        headers: {
+          Authorization: `token ${token}`,
+        },
+      }
+    );
+    if (response.status === 201) {
+      const gistUrl = response.data.html_url;
+      const openGistButton = "Go to Gist";
+      const selectedButton = await vscode.window.showInformationMessage(
+        `Gist Created: ${gistUrl}`,
+        openGistButton
+      );
+      if (selectedButton === openGistButton) {
+        vscode.env.openExternal(vscode.Uri.parse(gistUrl));
+      }
+    } else {
+      throw new Error(
+        `GitHub API responded with status code ${response.status}`
+      );
+    }
+  } catch (e) {
+    if (axios.isAxiosError(e)) {
+      if (e.response?.status === 403) {
+        vscode.window.showErrorMessage(
+          "Rate limit exceeded. Please try again later."
+        );
+      } else if (e.response?.status === 401) {
+        vscode.window.showErrorMessage(
+          "Invalid GitHub PAT. Please check your token."
+        );
+      } else {
+        vscode.window.showErrorMessage(`Failed to create a gist: ${e.message}`);
+      }
+    } else {
+      vscode.window.showErrorMessage(
+        (e as string) || "An unexpected error occurred while creating a gist"
+      );
+    }
+  }
+};
+
+const createGistFromActiveEditor = async () => {
+  const token = await getSessionToken();
+
+  const activeDocument = vscode.window.activeTextEditor?.document;
+  const activeEditorFileName = activeDocument?.fileName.split("/").pop() || "";
+  const activeEditorFileContent = activeDocument?.getText() || "";
+
+  if (!activeEditorFileName || !activeEditorFileContent) {
+    throw new Error("Please open a file in editor");
+  }
+
+  const isPublic = await getGistVisibility();
+
+  const gists: Gist[] = [];
+  gists.push({
+    [activeEditorFileName]: {
+      content: activeEditorFileContent,
+    },
+  });
+
+  return uploadGistAndHandleErrors(gists, isPublic, token);
+};
+
+const createGistFromExplorer = async (uri: vscode.Uri | undefined) => {
+  const token = await getSessionToken();
+
+  const gists = readFilesRecursively(uri?.fsPath);
+
+  if (gists.length < 1) {
+    throw new Error("Select a valid file or folder from the vscode explorer");
+  }
+
+  const isPublic = await getGistVisibility();
+
+  return uploadGistAndHandleErrors(gists, isPublic, token);
+};
+
+const createGistFromFilePicker = async () => {
+  const token = await getSessionToken();
+
+  const filesToUpload = await vscode.window.showOpenDialog({
+    canSelectMany: true,
+    canSelectFolders: false,
+  });
+
+  if (!filesToUpload) {
+    throw new Error("Please select a file");
+  }
+
+  const gists: Gist[] = [];
+  for (const fileUri of filesToUpload) {
+    const fileName = fileUri.path.split("/").pop() || "";
+
+    let fileContent;
+    try {
+      fileContent = fs.readFileSync(fileUri.fsPath, "utf8");
+    } catch (e) {
+      vscode.window.showErrorMessage(`Failed to read the file: ${fileName}`);
+      throw e;
+    }
+
+    gists.push({
+      [fileName]: {
+        content: fileContent,
+      },
+    });
+  }
+
+  const isPublic = await getGistVisibility();
+
+  return uploadGistAndHandleErrors(gists, isPublic, token);
+};
+
+const createGistFromSelection = async () => {
+  const token = await getSessionToken();
+
+  const activeEditor = vscode.window.activeTextEditor;
+  const activeEditorFileName =
+    activeEditor?.document.fileName.split("/").pop() || "";
+  const selectedTextContent =
+    (activeEditor && activeEditor.document.getText(activeEditor.selection)) ||
+    "";
+
+  if (!activeEditorFileName || !selectedTextContent) {
+    throw new Error("Please select some text to create gist");
+  }
+
+  const isPublic = await getGistVisibility();
+
+  const gists: Gist[] = [];
+  gists.push({
+    [activeEditorFileName]: {
+      content: selectedTextContent,
+    },
+  });
+
+  return uploadGistAndHandleErrors(gists, isPublic, token);
+};
+
+export async function activate(context: vscode.ExtensionContext) {
+  const createGistFromActiveEditorDisposable = vscode.commands.registerCommand(
+    "code-to-gist.createGistFromActiveEditor",
+    createGistFromActiveEditor
+  );
+  const createGistFromExplorerDisposable = vscode.commands.registerCommand(
+    "code-to-gist.createGistFromExplorer",
+    createGistFromExplorer
+  );
+  const createGistFromFilePickerDisposable = vscode.commands.registerCommand(
+    "code-to-gist.createGistFromFilePicker",
+    createGistFromFilePicker
+  );
+  const createGistFromSelectionDisposable = vscode.commands.registerCommand(
+    "code-to-gist.createGistFromSelection",
+    createGistFromSelection
+  );
+
+  context.subscriptions.push(createGistFromActiveEditorDisposable);
+  context.subscriptions.push(createGistFromExplorerDisposable);
+  context.subscriptions.push(createGistFromFilePickerDisposable);
+  context.subscriptions.push(createGistFromSelectionDisposable);
 
   let myStatusBarItem = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Left,
     1
   );
-  myStatusBarItem.command = "code-to-gist.createGist";
+  myStatusBarItem.command = "code-to-gist.createGistFromFilePicker";
   myStatusBarItem.text = `$(file-code) Create Gist`;
   myStatusBarItem.tooltip = "Create Gist";
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,16 +3,24 @@ import axios from "axios";
 import * as fs from "fs";
 import * as path from "path";
 
+const GITHUB_API_URL = "https://api.github.com/gists";
+const GITHUB_AUTH_SCHEME = "github";
+const GITHUB_AUTH_SCOPES = ["gist"];
+const COMMAND_CREATE_GIST_ACTIVE_EDITOR = "code-to-gist.createGistFromActiveEditor";
+const COMMAND_CREATE_GIST_EXPLORER = "code-to-gist.createGistFromExplorer";
+const COMMAND_CREATE_GIST_FILE_PICKER = "code-to-gist.createGistFromFilePicker";
+const COMMAND_CREATE_GIST_SELECTION = "code-to-gist.createGistFromSelection";
+
 interface Gist {
   [key: string]: { content: string };
 }
 
 const getSessionToken = async () => {
-  const session = await vscode.authentication.getSession("github", ["gist"], {
+  const session = await vscode.authentication.getSession(GITHUB_AUTH_SCHEME, GITHUB_AUTH_SCOPES, {
     createIfNone: true,
   });
   if (!session) {
-    throw new Error("GitHub authentication failed");
+    throw new Error("Failed to authenticate with GitHub. Please check your credentials.");
   }
 
   return session.accessToken;
@@ -26,7 +34,7 @@ const getGistVisibility = async () => {
     }
   );
   if (!gistVisibility) {
-    throw new Error("Please select a gist visibility");
+    throw new Error("Gist visibility selection was cancelled or invalid.");
   }
 
   return gistVisibility === "public";
@@ -96,7 +104,7 @@ const uploadGistAndHandleErrors = async (
 ) => {
   try {
     const response = await axios.post(
-      "https://api.github.com/gists",
+      GITHUB_API_URL,
       {
         files: Object.assign({}, ...gists),
         public: isPublic,
@@ -244,19 +252,19 @@ const createGistFromSelection = async () => {
 
 export async function activate(context: vscode.ExtensionContext) {
   const createGistFromActiveEditorDisposable = vscode.commands.registerCommand(
-    "code-to-gist.createGistFromActiveEditor",
+    COMMAND_CREATE_GIST_ACTIVE_EDITOR,
     createGistFromActiveEditor
   );
   const createGistFromExplorerDisposable = vscode.commands.registerCommand(
-    "code-to-gist.createGistFromExplorer",
+    COMMAND_CREATE_GIST_EXPLORER,
     createGistFromExplorer
   );
   const createGistFromFilePickerDisposable = vscode.commands.registerCommand(
-    "code-to-gist.createGistFromFilePicker",
+    COMMAND_CREATE_GIST_FILE_PICKER,
     createGistFromFilePicker
   );
   const createGistFromSelectionDisposable = vscode.commands.registerCommand(
-    "code-to-gist.createGistFromSelection",
+    COMMAND_CREATE_GIST_SELECTION,
     createGistFromSelection
   );
 


### PR DESCRIPTION
This commit adds functionality to create a gist right from the editor using the already existing underlying logic. However, the current behaviour of the 'create gist' button at the left of status bar remains the same.

## FEATURES ADDED
1. Create Gist of selected text from inside a file
<img width="538" alt="Screenshot 2023-07-17 at 4 31 04 PM" src="https://github.com/Developerayo/code-to-gist/assets/67174734/6bdaa18a-9777-4ed7-9212-d529a7366ee9">

2. Create Gist of a whole file using a button in the titlebar tabs view
<img width="489" alt="Screenshot 2023-07-17 at 4 29 50 PM" src="https://github.com/Developerayo/code-to-gist/assets/67174734/b78c2265-1cbe-450c-993b-6317e56a7af0">

3. Create Gist of a file in the explorer
<img width="395" alt="Screenshot 2023-07-17 at 4 32 25 PM" src="https://github.com/Developerayo/code-to-gist/assets/67174734/8bb4b3ca-353e-4cb7-b1da-7dcd2fb89e26">

4. Create Gist of all files in a folder in the explorer view (NOTE: this recursively loops through every file and sub-files in the cuurent folder and sub folders)
(Same picture as in no.3)

## HANDLED ERRORS
When triggering the added commands from the command pallete in vscode, there might be some error, e.g
- 'Create gist from active editor' only works when there is an active editor
- 'Create fist from explorer' only works when there a file or folder is selected from the explorer
- 'Create gist from selection' only works when text is selected inside a an editor
Although this errors were handled, they were not added to the documentation

## TODOS
- Add the new features to the docs
- Update the 'Troubleshooting' section in the docs

Overall this commit comes with a little refactor, but the underlying logic remains untouched.